### PR TITLE
fix up the problem in model_profiling when fed 'Modulelist'

### DIFF
--- a/utils/model_profiling.py
+++ b/utils/model_profiling.py
@@ -103,11 +103,23 @@ def module_profiling(self, input, output, verbose):
         self.n_params = 0
         self.n_seconds = 0
         num_children = 0
-        for m in self.children():
+
+        def get_children(m):
+            children_list = []
+            for child in m.children():
+                if isinstance(child, nn.ModuleList):
+                    children_list.extend(get_children(child))
+                else:
+                    children_list.append(child)
+            return children_list
+        
+        all_children = get_children(self)
+        num_children += len(all_children)
+        for m in all_children:
             self.n_macs += getattr(m, 'n_macs', 0)
             self.n_params += getattr(m, 'n_params', 0)
             self.n_seconds += getattr(m, 'n_seconds', 0)
-            num_children += 1
+        
         ignore_zeros_t = [
             nn.BatchNorm2d, nn.Dropout2d, nn.Dropout, nn.Sequential,
             nn.ReLU6, nn.ReLU, nn.MaxPool2d,


### PR DESCRIPTION
**Problem Introduction:** 
&ensp; Module.register_forward_hook function adds hooks to each module (with forward function) without ModuleList. So ModuleList module does not record the profile including macs and params. When traversing deep-first module.children fcuntion does not calculate the profile when this module is a instance of  ModuleList.

**Problem Reproduction:**
&ensp;  You can try to modify "self.blocks" in model.py to the instance of ModuleList.
```
def __init__(self):
  self.blocks = nn.ModuleList()
def forward(self, x):
  for block in self.blocks:
    x = block(x)
```

**Solution:**
&ensp;  I handle ModuleList specially, recording to each non-ModuleList submodule.